### PR TITLE
Add intro section for sequence info

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -204,6 +204,11 @@ h3 {
     transform: translateY(-2px); /* Effet de léger soulèvement */
 }
 
+/* Section initiale */
+#intro-page {
+    text-align: left;
+}
+
 /* Styles pour les sections des détails de compétence */
 .competence-detail-section {
     margin-top: 20px;

--- a/index.html
+++ b/index.html
@@ -14,7 +14,23 @@
             <p>Sélectionnez les éléments pour générer votre fiche.</p>
         </header>
 
-        <section class="selection-card">
+        <section id="intro-page" class="selection-card">
+            <div class="form-group">
+                <label for="sequence-name">Nom de la séquence :</label>
+                <input type="text" id="sequence-name" class="custom-select">
+            </div>
+            <div class="form-group">
+                <label for="session-name">Nom de la séance :</label>
+                <input type="text" id="session-name" class="custom-select">
+            </div>
+            <div class="form-group">
+                <label for="session-date">Date :</label>
+                <input type="date" id="session-date" class="custom-select">
+            </div>
+            <button id="start-btn" class="btn-primary">Continuer</button>
+        </section>
+
+        <section id="phase-group" class="selection-card" style="display: none;">
             <div class="form-group">
                 <label for="phase-select">Sélectionner une Phase :</label>
                 <div class="custom-select-wrapper">

--- a/js/pdf-generator.js
+++ b/js/pdf-generator.js
@@ -15,8 +15,23 @@ document.addEventListener('DOMContentLoaded', () => {
         const selectedExpectedResult = document.getElementById('expected-result-select').value;
         const selectedCompetence = document.getElementById('competence-select').value;
 
-        // Add selected items to PDF
+        // Add introductory information
         let yPos = 20;
+        doc.setFontSize(14);
+        if (window.sequenceName) {
+            doc.text(`Séquence : ${window.sequenceName}`, 10, yPos);
+            yPos += 7;
+        }
+        if (window.sessionName) {
+            doc.text(`Séance : ${window.sessionName}`, 10, yPos);
+            yPos += 7;
+        }
+        if (window.sessionDate) {
+            doc.text(`Date : ${window.sessionDate}`, 10, yPos);
+            yPos += 7;
+        }
+
+        // Add selected items to PDF
         doc.setFontSize(16);
         doc.text("Détails du Formulaire", 10, yPos);
         yPos += 10;

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,13 @@
 // js/script.js
 
 document.addEventListener('DOMContentLoaded', () => {
+    const introPage = document.getElementById('intro-page');
+    const startBtn = document.getElementById('start-btn');
+    const sequenceInput = document.getElementById('sequence-name');
+    const sessionInput = document.getElementById('session-name');
+    const dateInput = document.getElementById('session-date');
+
+    const phaseGroup = document.getElementById('phase-group');
     const phaseSelect = document.getElementById('phase-select');
     const activitySelect = document.getElementById('activity-select');
     const taskSelect = document.getElementById('task-select');
@@ -25,6 +32,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const onDonneResourcesDiv = document.getElementById('on-donne-resources');
     const generatePdfBtn = document.getElementById('generate-pdf-btn');
+
+    // Variables pour stocker les informations de l'introduction
+    window.sequenceName = '';
+    window.sessionName = '';
+    window.sessionDate = '';
 
     // Fonction pour réinitialiser les sélections suivantes et masquer les groupes
     function resetAndHide(startingLevel) {
@@ -76,6 +88,18 @@ document.addEventListener('DOMContentLoaded', () => {
             phaseSelect.appendChild(option);
         });
     }
+
+    // Lancer le formulaire après l'introduction
+    startBtn.addEventListener('click', () => {
+        window.sequenceName = sequenceInput.value.trim();
+        window.sessionName = sessionInput.value.trim();
+        window.sessionDate = dateInput.value;
+
+        introPage.style.display = 'none';
+        phaseGroup.style.display = 'block';
+
+        populatePhases();
+    });
 
     phaseSelect.addEventListener('change', () => {
         resetAndHide(1);
@@ -402,6 +426,5 @@ document.addEventListener('DOMContentLoaded', () => {
         doc.save('fiche_pedagogique.pdf');
     });
 
-    // Appel initial pour peupler le premier sélecteur
-    populatePhases();
+    // Les phases seront peuplées après la saisie des informations initiales
 });

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ Les données sont structurées hiérarchiquement dans `js/data.js` pour facilite
     cd Formulaire
     ```
 2.  **Ouvrir `index.html`:** Ouvrez simplement le fichier `index.html` dans votre navigateur web.
+3.  **Saisir les informations initiales :** Entrez le nom de la séquence, le nom de la séance et la date puis cliquez sur **Continuer** pour accéder au formulaire.
 
 ## Guide d'Utilisation (docs/guide-utilisation.md)
 


### PR DESCRIPTION
## Summary
- add intro form with sequence/session inputs and start button
- hide phase selector until form start
- store intro info and show phase selection on continue
- add intro data in generated PDF
- document new intro step

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68546234e8d0832690575f6b9f268215