### PR TITLE
Add navigation wizard for form steps

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -204,6 +204,32 @@ h3 {
     transform: translateY(-2px); /* Effet de léger soulèvement */
 }
 
+.btn-secondary {
+    display: block;
+    width: 100%;
+    padding: 15px;
+    background: linear-gradient(135deg, #bdc3c7, #95a5a6);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 1.1em;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+    margin-top: 30px;
+}
+
+.btn-secondary:hover {
+    background: linear-gradient(135deg, #d0d3d4, #bdc3c7);
+    transform: translateY(-2px);
+}
+
+.navigation {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+}
+
 /* Section initiale */
 #intro-page {
     text-align: left;

--- a/index.html
+++ b/index.html
@@ -27,7 +27,10 @@
                 <label for="session-date">Date :</label>
                 <input type="date" id="session-date" class="custom-select">
             </div>
-            <button id="start-btn" class="btn-primary">Continuer</button>
+            <div class="navigation">
+                <button class="btn-secondary prev-btn">Précédent</button>
+                <button id="start-btn" class="btn-primary next-btn">Suivant</button>
+            </div>
         </section>
 
         <section id="phase-group" class="selection-card" style="display: none;">
@@ -38,6 +41,10 @@
                         <option value="">--Choisir une phase--</option>
                     </select>
                 </div>
+            </div>
+            <div class="navigation">
+                <button class="btn-secondary prev-btn">Précédent</button>
+                <button class="btn-primary next-btn">Suivant</button>
             </div>
         </section>
 
@@ -50,6 +57,10 @@
                     </select>
                 </div>
             </div>
+            <div class="navigation">
+                <button class="btn-secondary prev-btn">Précédent</button>
+                <button class="btn-primary next-btn">Suivant</button>
+            </div>
         </section>
 
         <section class="selection-card" id="task-group" style="display: none;">
@@ -60,6 +71,10 @@
                         <option value="">--Choisir une tâche--</option>
                     </select>
                 </div>
+            </div>
+            <div class="navigation">
+                <button class="btn-secondary prev-btn">Précédent</button>
+                <button class="btn-primary next-btn">Suivant</button>
             </div>
         </section>
 
@@ -72,12 +87,20 @@
                     </select>
                 </div>
             </div>
+            <div class="navigation">
+                <button class="btn-secondary prev-btn">Précédent</button>
+                <button class="btn-primary next-btn">Suivant</button>
+            </div>
         </section>
 
         <section class="selection-card" id="expected-result-group" style="display: none;">
             <h2>Résultat(s) attendu(s) :</h2>
             <div id="expected-result-checkboxes" class="checkbox-group">
                 </div>
+            <div class="navigation">
+                <button class="btn-secondary prev-btn">Précédent</button>
+                <button class="btn-primary next-btn">Suivant</button>
+            </div>
         </section>
 
         <section class="selection-card" id="competence-group" style="display: none;">
@@ -88,6 +111,10 @@
                         <option value="">--Choisir une compétence--</option>
                     </select>
                 </div>
+            </div>
+            <div class="navigation">
+                <button class="btn-secondary prev-btn">Précédent</button>
+                <button class="btn-primary next-btn">Suivant</button>
             </div>
         </section>
 
@@ -111,12 +138,20 @@
                 <div class="checkbox-group" id="criteres-evaluation-checkboxes">
                     </div>
             </div>
+            <div class="navigation">
+                <button class="btn-secondary prev-btn">Précédent</button>
+                <button class="btn-primary next-btn">Suivant</button>
+            </div>
         </section>
 
         <section class="selection-card" id="on-donne-resources" style="display: none;">
             <h2>Ressources "On donne" :</h2>
             <div id="resources-checkboxes" class="checkbox-group">
                 </div>
+            <div class="navigation">
+                <button class="btn-secondary prev-btn">Précédent</button>
+                <button class="btn-primary next-btn">Suivant</button>
+            </div>
         </section>
 
         <button id="generate-pdf-btn" class="btn-primary" style="display: none;">Générer une Fiche PDF</button>

--- a/js/script.js
+++ b/js/script.js
@@ -33,10 +33,98 @@ document.addEventListener('DOMContentLoaded', () => {
     const onDonneResourcesDiv = document.getElementById('on-donne-resources');
     const generatePdfBtn = document.getElementById('generate-pdf-btn');
 
+    const sections = [
+        introPage,
+        phaseGroup,
+        activityGroup,
+        taskGroup,
+        problematicGroup,
+        expectedResultGroup,
+        competenceGroup,
+        competenceDetailsDiv,
+        onDonneResourcesDiv
+    ];
+
+    const nextButtons = document.querySelectorAll('.next-btn');
+    const prevButtons = document.querySelectorAll('.prev-btn');
+    let currentStep = 0;
+
     // Variables pour stocker les informations de l'introduction
     window.sequenceName = '';
     window.sessionName = '';
     window.sessionDate = '';
+
+    function showStep(index) {
+        sections.forEach((sec, i) => {
+            sec.style.display = i === index ? 'block' : 'none';
+        });
+        generatePdfBtn.style.display = index === sections.length - 1 ? 'block' : 'none';
+
+        const nav = sections[index].querySelector('.navigation');
+        if (nav) {
+            const prev = nav.querySelector('.prev-btn');
+            const next = nav.querySelector('.next-btn');
+            if (prev) prev.style.display = index === 0 ? 'none' : 'block';
+            if (next) next.style.display = index === sections.length - 1 ? 'none' : 'block';
+        }
+    }
+
+    function validateStep(step) {
+        switch (step) {
+            case 0:
+                if (!sequenceInput.value.trim() || !sessionInput.value.trim() || !dateInput.value) {
+                    alert('Veuillez remplir tous les champs.');
+                    return false;
+                }
+                if (phaseSelect.options.length === 1) {
+                    populatePhases();
+                }
+                window.sequenceName = sequenceInput.value.trim();
+                window.sessionName = sessionInput.value.trim();
+                window.sessionDate = dateInput.value;
+                return true;
+            case 1:
+                if (!phaseSelect.value) { alert('Sélectionnez une phase.'); return false; }
+                return true;
+            case 2:
+                if (!activitySelect.value) { alert('Sélectionnez une activité.'); return false; }
+                return true;
+            case 3:
+                if (!taskSelect.value) { alert('Sélectionnez une tâche.'); return false; }
+                return true;
+            case 4:
+                if (!problematicSelect.value) { alert('Sélectionnez une problématique.'); return false; }
+                return true;
+            case 5:
+                if (expectedResultCheckboxesDiv.querySelectorAll('input[name="expectedResult"]:checked').length === 0) {
+                    alert('Sélectionnez au moins un résultat attendu.');
+                    return false;
+                }
+                return true;
+            case 6:
+                if (!competenceSelect.value) { alert('Sélectionnez une compétence.'); return false; }
+                return true;
+            default:
+                return true;
+        }
+    }
+
+    function nextStep() {
+        if (validateStep(currentStep)) {
+            currentStep = Math.min(currentStep + 1, sections.length - 1);
+            showStep(currentStep);
+        }
+    }
+
+    function prevStep() {
+        currentStep = Math.max(currentStep - 1, 0);
+        showStep(currentStep);
+    }
+
+    nextButtons.forEach(btn => btn.addEventListener('click', nextStep));
+    prevButtons.forEach(btn => btn.addEventListener('click', prevStep));
+
+    showStep(currentStep);
 
     // Fonction pour réinitialiser les sélections suivantes et masquer les groupes
     function resetAndHide(startingLevel) {
@@ -89,17 +177,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Lancer le formulaire après l'introduction
-    startBtn.addEventListener('click', () => {
-        window.sequenceName = sequenceInput.value.trim();
-        window.sessionName = sessionInput.value.trim();
-        window.sessionDate = dateInput.value;
-
-        introPage.style.display = 'none';
-        phaseGroup.style.display = 'block';
-
-        populatePhases();
-    });
+    // Ancien bouton de démarrage utilisé comme premier "Suivant"
 
     phaseSelect.addEventListener('change', () => {
         resetAndHide(1);
@@ -280,9 +358,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             populateOnDonneResources(); // Appeler cette fonction pour afficher les ressources "On donne"
         } else {
-            // Si aucune compétence n'est sélectionnée, assurez-vous que les ressources "On donne" sont masquées
-            onDonneResourcesDiv.style.display = 'none';
-            generatePdfBtn.style.display = 'none';
+            resourcesCheckboxesDiv.innerHTML = '';
         }
     });
 
@@ -293,8 +369,6 @@ document.addEventListener('DOMContentLoaded', () => {
             const checkboxItem = createCheckboxItem(`resource-${index}`, 'onDonneResource', resource, resource, false);
             resourcesCheckboxesDiv.appendChild(checkboxItem);
         });
-        onDonneResourcesDiv.style.display = 'block';
-        generatePdfBtn.style.display = 'block';
     }
 
     // Génération du PDF


### PR DESCRIPTION
## Summary
- add Previous/Suivant navigation buttons to each form section
- style secondary buttons and navigation layout
- implement step-based navigation with validation in `script.js`

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6854642801d883269e81d2397bb34c1b