### PR TITLE
Allow previous selections remain visible

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -63,8 +63,9 @@ document.addEventListener('DOMContentLoaded', () => {
     window.sessionDate = '';
 
     function showStep(index) {
+        // Afficher la section courante et conserver les précédentes visibles
         sections.forEach((sec, i) => {
-            sec.style.display = i === index ? 'block' : 'none';
+            sec.style.display = i <= index ? 'block' : 'none';
         });
         generatePdfBtn.style.display = index === sections.length - 1 ? 'block' : 'none';
     }


### PR DESCRIPTION
## Summary
- keep earlier sections visible while progressing through the form

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68569b2836148326b57e256a1297b392